### PR TITLE
perf(docker): respond like real daemon

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -373,7 +373,7 @@ func (c *ContainerService) ContainerWait(ctx context.Context, ctn string, condit
 	}
 
 	go func() {
-		time.Sleep(3 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		ctnCh <- response
 	}()

--- a/docker/container.go
+++ b/docker/container.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/stringid"
 )
 
@@ -215,13 +216,25 @@ func (c *ContainerService) ContainerLogs(ctx context.Context, ctn string, option
 	}
 
 	// create response object to return
-	response := ioutil.NopCloser(
-		bytes.NewReader(
-			[]byte("hello from github.com/go-vela/mock/docker"),
-		),
-	)
+	response := new(bytes.Buffer)
 
-	return response, nil
+	// write stdout logs to response buffer
+	_, err := stdcopy.
+		NewStdWriter(response, stdcopy.Stdout).
+		Write([]byte("hello to stdout from github.com/go-vela/mock/docker"))
+	if err != nil {
+		return nil, err
+	}
+
+	// write stderr logs to response buffer
+	_, err = stdcopy.
+		NewStdWriter(response, stdcopy.Stderr).
+		Write([]byte("hello to stderr from github.com/go-vela/mock/docker"))
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.NopCloser(response), nil
 }
 
 // ContainerPause is a helper function to simulate


### PR DESCRIPTION
The [golangci check](https://github.com/go-vela/mock/pull/37#pullrequestreview-382061283) is failing due to the `stylecheck` linter (`ST1005` error) because the error message we're returning in the mock starts with a capital letter.

Normally, I'd go and make the error message not start with a capital letter, but I actually copied the error message from the real Docker daemon:

```
$ docker pull alpine:blah
Error response from daemon: manifest for alpine:blah not found: manifest unknown
```

I vote we skip this linter error because this is how the real Docker daemon responds 👍 