### PR TITLE
feat(docker): enable ignoring not found

### DIFF
--- a/docker/image.go
+++ b/docker/image.go
@@ -158,8 +158,20 @@ func (i *ImageService) ImagePull(ctx context.Context, image string, options type
 		return nil, errors.New("no container provided")
 	}
 
-	// check if the image is not found
-	if strings.Contains(image, "notfound") || strings.Contains(image, "not-found") {
+	// check if the image is notfound and
+	// check if the notfound should be ignored
+	if strings.Contains(image, "notfound") &&
+		!strings.Contains(image, "ignorenotfound") {
+		return nil,
+			errdefs.NotFound(
+				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),
+			)
+	}
+
+	// check if the image is not-found and
+	// check if the not-found should be ignored
+	if strings.Contains(image, "not-found") &&
+		!strings.Contains(image, "ignore-not-found") {
 		return nil,
 			errdefs.NotFound(
 				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),


### PR DESCRIPTION
Similar to https://github.com/go-vela/mock/pull/37, https://github.com/go-vela/mock/pull/39 and https://github.com/go-vela/mock/pull/40:

The [golangci check](https://github.com/go-vela/mock/pull/39#pullrequestreview-382219496) is failing due to the `stylecheck` linter (`ST1005` error) because the error message we're returning in the mock starts with a capital letter.

I vote we skip this linter error because this is how the real Docker daemon responds 👍