### PR TITLE
fix: update mock to return JSON results

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -227,7 +227,7 @@ func removeBuild(c *gin.Context) {
 		return
 	}
 
-	c.String(http.StatusOK, fmt.Sprintf("Build %s removed", b))
+	c.JSON(http.StatusOK, fmt.Sprintf("Build %s removed", b))
 }
 
 // restartBuild has a param :build returns mock JSON for a http POST.

--- a/server/hook.go
+++ b/server/hook.go
@@ -143,5 +143,5 @@ func removeHook(c *gin.Context) {
 		return
 	}
 
-	c.String(200, fmt.Sprintf("Hook %s removed", s))
+	c.JSON(200, fmt.Sprintf("Hook %s removed", s))
 }

--- a/server/log.go
+++ b/server/log.go
@@ -95,7 +95,7 @@ func removeServiceLog(c *gin.Context) {
 		return
 	}
 
-	c.String(http.StatusOK, fmt.Sprintf("Log %s removed", s))
+	c.JSON(http.StatusOK, fmt.Sprintf("Log %s removed", s))
 }
 
 // getStepLog has a param :step returns mock JSON for a http GET.
@@ -166,5 +166,5 @@ func removeStepLog(c *gin.Context) {
 		return
 	}
 
-	c.String(http.StatusOK, fmt.Sprintf("Log %s removed", s))
+	c.JSON(http.StatusOK, fmt.Sprintf("Log %s removed", s))
 }

--- a/server/repo.go
+++ b/server/repo.go
@@ -158,7 +158,7 @@ func removeRepo(c *gin.Context) {
 		return
 	}
 
-	c.String(http.StatusOK, fmt.Sprintf("Repo %s removed", r))
+	c.JSON(http.StatusOK, fmt.Sprintf("Repo %s removed", r))
 }
 
 // repairRepo has a param :repo returns mock JSON for a http PATCH.
@@ -175,7 +175,7 @@ func repairRepo(c *gin.Context) {
 		return
 	}
 
-	c.String(http.StatusOK, fmt.Sprintf("Repo %s repaired", r))
+	c.JSON(http.StatusOK, fmt.Sprintf("Repo %s repaired", r))
 }
 
 // chownRepo has a param :repo returns mock JSON for a http PATCH.
@@ -192,5 +192,5 @@ func chownRepo(c *gin.Context) {
 		return
 	}
 
-	c.String(http.StatusOK, fmt.Sprintf("Repo %s changed org", r))
+	c.JSON(http.StatusOK, fmt.Sprintf("Repo %s changed org", r))
 }

--- a/server/secret.go
+++ b/server/secret.go
@@ -161,5 +161,5 @@ func removeSecret(c *gin.Context) {
 		return
 	}
 
-	c.String(http.StatusOK, fmt.Sprintf("Secret %s removed", n))
+	c.JSON(http.StatusOK, fmt.Sprintf("Secret %s removed", n))
 }

--- a/server/service.go
+++ b/server/service.go
@@ -140,5 +140,5 @@ func removeService(c *gin.Context) {
 		return
 	}
 
-	c.String(200, fmt.Sprintf("Service %s removed", s))
+	c.JSON(200, fmt.Sprintf("Service %s removed", s))
 }

--- a/server/step.go
+++ b/server/step.go
@@ -149,5 +149,5 @@ func removeStep(c *gin.Context) {
 		return
 	}
 
-	c.String(200, fmt.Sprintf("Step %s removed", s))
+	c.JSON(200, fmt.Sprintf("Step %s removed", s))
 }


### PR DESCRIPTION
Currently this causes issues with some of the results being returned.

Specifically, I'm getting "empty" responses when using the `go-vela/sdk-go` library in the `go-vela/cli` codebase 👍 

This is because we expect a JSON type response in our SDK

https://github.com/go-vela/sdk-go/blob/21002d8b294643bc7749017632622bc0f70a3b1c/vela/client.go#L334-L356