### PR TITLE
chore: add missing DialHijack method for Docker client

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -6,7 +6,7 @@ package docker
 
 // Version represents the supported
 // Docker API version for the mock.
-const Version = "v1.38"
+const Version = "v1.40"
 
 // New returns a client that is capable of handling
 // Docker client calls and returning stub responses.

--- a/docker/mock.go
+++ b/docker/mock.go
@@ -61,6 +61,13 @@ func (m *mock) DialSession(ctx context.Context, proto string, meta map[string][]
 	return nil, nil
 }
 
+// DialHijack is a helper function to simulate
+// returning a hijacked connection with
+// negotiated protocol proto.
+func (m *mock) DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error) {
+	return nil, nil
+}
+
 // Dialer is a helper function to simulate
 // returning a dialer for the raw stream
 // connection, with HTTP/1.1 header, that can


### PR DESCRIPTION
This will be required to upgrade `docker/docker` dependencies in [go-vela/pkg-runtime](https://github.com/go-vela/pkg-runtime).

You can find a full list of functions the real Docker client supports here:

https://godoc.org/github.com/docker/docker/client#CommonAPIClient

This mock is used to "fake out" every function provided in that client 👍 