### PR TITLE
feat: add pipeline endpoints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,7 +131,9 @@ issues:
     # prevent linters from running on *_test.go files
     - path: _test\.go
       linters:
+        - dupl
         - funlen
         - goconst
         - gocyclo
         - gomnd
+        - lll

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.14 // indirect
+	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -1,0 +1,248 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/types"
+	"github.com/go-vela/types/yaml"
+)
+
+const (
+	// CompileResp represents a YAML return for an compiled pipeline.
+	CompileResp = `---
+version: "1"
+
+secrets:
+  - name: docker_username
+    key: go-vela/docker/username
+    engine: native
+    type: org
+
+  - name: docker_password
+    key: go-vela/docker/password
+    engine: native
+    type: org
+
+steps:
+  - name: go_test
+    image: golang:latest
+    environment:
+      CGO_ENABLED: "0"
+      GOOS: linux
+    commands:
+      - go test ./...
+
+  - name: go_build
+    image: golang:latest
+    environment:
+      CGO_ENABLED: "0"
+      GOOS: linux
+    commands:
+      - go build
+
+  - name: non-template-echo
+    image: golang:latest
+    commands:
+      - echo hello
+
+templates:
+  - name: sample
+    source: github.com/go-vela/vela-tutorials/templates/sample.yml
+    type: github
+`
+
+	// ExpandResp represents a YAML return for an expanded pipeline.
+	ExpandResp = `---
+version: "1"
+
+secrets:
+  - name: docker_username
+    key: go-vela/docker/username
+    engine: native
+    type: org
+
+  - name: docker_password
+    key: go-vela/docker/password
+    engine: native
+    type: org
+
+steps:
+  - name: go_test
+    image: golang:latest
+    environment:
+      CGO_ENABLED: "0"
+      GOOS: linux
+    commands:
+      - go test ./...
+
+  - name: go_build
+    image: golang:latest
+    environment:
+      CGO_ENABLED: "0"
+      GOOS: linux
+    commands:
+      - go build
+
+  - name: non-template-echo
+    image: golang:latest
+    commands:
+      - echo hello
+
+templates:
+  - name: sample
+    source: github.com/go-vela/vela-tutorials/templates/sample.yml
+    type: github
+`
+
+	// PipelineResp represents a YAML return for a single pipeline.
+	PipelineResp = `---
+version: "1"
+
+secrets:
+  - name: docker_username
+    key: go-vela/docker/username
+    engine: native
+    type: org
+
+  - name: docker_password
+    key: go-vela/docker/password
+    engine: native
+    type: org
+
+steps:
+  - name: go
+    template:
+      name: sample
+
+  - name: non-template-echo
+    image: golang:latest
+    commands:
+      - echo hello
+
+templates:
+  - name: sample
+    source: github.com/go-vela/vela-tutorials/templates/sample.yml
+    type: github
+`
+
+	// TemplateResp represents a YAML return for templates in a pipeline.
+	TemplateResp = `---
+sample:
+  name: sample
+  source: github.com/go-vela/vela-tutorials/templates/sample.yml
+  type: github
+`
+)
+
+// getPipeline has a param :repo returns mock YAML for a http GET.
+//
+// Pass "not-found" to :repo to test receiving a http 404 response
+func getPipeline(c *gin.Context) {
+	r := c.Param("repo")
+
+	if strings.Contains(r, "not-found") {
+		msg := fmt.Sprintf("Repo %s does not exist", r)
+
+		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+
+		return
+	}
+
+	data := []byte(PipelineResp)
+
+	var body yaml.Build
+	_ = json.Unmarshal(data, &body)
+
+	c.YAML(http.StatusOK, body)
+}
+
+// compilePipeline has a param :repo returns mock YAML for a http GET.
+//
+// Pass "not-found" to :repo to test receiving a http 404 response
+func compilePipeline(c *gin.Context) {
+	r := c.Param("repo")
+
+	if strings.Contains(r, "not-found") {
+		msg := fmt.Sprintf("Repo %s does not exist", r)
+
+		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+
+		return
+	}
+
+	data := []byte(CompileResp)
+
+	var body yaml.Build
+	_ = json.Unmarshal(data, &body)
+
+	c.YAML(http.StatusOK, body)
+}
+
+// expandPipeline has a param :repo returns mock YAML for a http GET.
+//
+// Pass "not-found" to :repo to test receiving a http 404 response
+func expandPipeline(c *gin.Context) {
+	r := c.Param("repo")
+
+	if strings.Contains(r, "not-found") {
+		msg := fmt.Sprintf("Repo %s does not exist", r)
+
+		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+
+		return
+	}
+
+	data := []byte(ExpandResp)
+
+	var body yaml.Build
+	_ = json.Unmarshal(data, &body)
+
+	c.YAML(http.StatusOK, body)
+}
+
+// getTemplates has a param :repo returns mock YAML for a http GET.
+//
+// Pass "not-found" to :repo to test receiving a http 404 response
+func getTemplates(c *gin.Context) {
+	r := c.Param("repo")
+
+	if strings.Contains(r, "not-found") {
+		msg := fmt.Sprintf("Repo %s does not exist", r)
+
+		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+
+		return
+	}
+
+	data := []byte(TemplateResp)
+
+	body := make(map[string]*yaml.Template)
+	_ = json.Unmarshal(data, &body)
+
+	c.YAML(http.StatusOK, body)
+}
+
+// validatePipeline has a param :repo returns mock YAML for a http GET.
+//
+// Pass "not-found" to :repo to test receiving a http 404 response
+func validatePipeline(c *gin.Context) {
+	r := c.Param("repo")
+
+	if strings.Contains(r, "not-found") {
+		msg := fmt.Sprintf("Repo %s does not exist", r)
+
+		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, "pipeline is valid")
+}

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -5,7 +5,6 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -13,6 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-vela/types"
 	"github.com/go-vela/types/yaml"
+
+	yml "github.com/buildkite/yaml"
 )
 
 const (
@@ -159,7 +160,7 @@ func getPipeline(c *gin.Context) {
 	data := []byte(PipelineResp)
 
 	var body yaml.Build
-	_ = json.Unmarshal(data, &body)
+	_ = yml.Unmarshal(data, &body)
 
 	c.YAML(http.StatusOK, body)
 }
@@ -181,7 +182,7 @@ func compilePipeline(c *gin.Context) {
 	data := []byte(CompileResp)
 
 	var body yaml.Build
-	_ = json.Unmarshal(data, &body)
+	_ = yml.Unmarshal(data, &body)
 
 	c.YAML(http.StatusOK, body)
 }
@@ -203,7 +204,7 @@ func expandPipeline(c *gin.Context) {
 	data := []byte(ExpandResp)
 
 	var body yaml.Build
-	_ = json.Unmarshal(data, &body)
+	_ = yml.Unmarshal(data, &body)
 
 	c.YAML(http.StatusOK, body)
 }
@@ -225,7 +226,7 @@ func getTemplates(c *gin.Context) {
 	data := []byte(TemplateResp)
 
 	body := make(map[string]*yaml.Template)
-	_ = json.Unmarshal(data, &body)
+	_ = yml.Unmarshal(data, &body)
 
 	c.YAML(http.StatusOK, body)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,13 @@ func FakeHandler() http.Handler {
 	e.PUT("/api/v1/repos/:org/:repo/builds/:build/steps/:step/logs", updateStepLog)
 	e.DELETE("/api/v1/repos/:org/:repo/builds/:build/steps/:step/logs", removeStepLog)
 
+	// mock endpoints for pipeline calls
+	e.GET("/api/v1/pipelines/:org/:repo", getPipeline)
+	e.POST("/api/v1/pipelines/:org/:repo/compile", compilePipeline)
+	e.POST("/api/v1/pipelines/:org/:repo/expand", expandPipeline)
+	e.GET("/api/v1/pipelines/:org/:repo/templates", getTemplates)
+	e.POST("/api/v1/pipelines/:org/:repo/validate", validatePipeline)
+
 	// mock endpoints for repo calls
 	e.GET("/api/v1/repos/:org/:repo", getRepo)
 	e.GET("/api/v1/repos", getRepos)


### PR DESCRIPTION
Part of the [Cargill/Target Hackathon](https://gophers.slack.com/archives/CNRRKE8KY/p1602194963000100) for Vela

Related to https://github.com/go-vela/server/pull/203

This adds a collection of new `/api/v1/pipelines` endpoints:

```
GET   /api/v1/pipelines/:org/:repo
POST  /api/v1/pipelines/:org/:repo/compile
POST  /api/v1/pipelines/:org/:repo/expand
GET   /api/v1/pipelines/:org/:repo/templates
POST  /api/v1/pipelines/:org/:repo/validate
```

