### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,3 +49,70 @@ cd $HOME/go-vela/mock
 # Add a remote branch pointing to your fork
 git remote add fork https://github.com/your_fork/mock
 ```
+
+### Development
+
+* Navigate to the repository code:
+
+```bash
+# Change into the project directory
+cd $HOME/go-vela/mock
+```
+
+* Write your code
+  * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
+
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
+
+* Ensure your code meets the project standards:
+
+```bash
+# Clean the code with `go`
+go mod tidy
+go fmt ./...
+go vet ./...
+```
+
+* Push to your fork:
+
+```bash
+# Push your code up to your fork
+git push fork master
+```
+
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,21 +32,21 @@ We are always open to new PRs! You can follow the below guide for learning how y
 * Clone this repository to your workstation:
 
 ```bash
-# Clone the project
+# clone the project
 git clone git@github.com:go-vela/mock.git $HOME/go-vela/mock
 ```
 
 * Navigate to the repository code:
 
 ```bash
-# Change into the project directory
+# change into the project directory
 cd $HOME/go-vela/mock
 ```
 
 * Point the original code at your fork:
 
 ```bash
-# Add a remote branch pointing to your fork
+# add a remote branch pointing to your fork
 git remote add fork https://github.com/your_fork/mock
 ```
 
@@ -55,11 +55,11 @@ git remote add fork https://github.com/your_fork/mock
 * Navigate to the repository code:
 
 ```bash
-# Change into the project directory
+# change into the project directory
 cd $HOME/go-vela/mock
 ```
 
-* Write your code
+* Write your code and tests to implement the changes you desire.
   * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
   * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
 
@@ -78,19 +78,24 @@ cd $HOME/go-vela/mock
 
     Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
 
-* Ensure your code meets the project standards:
+* Test the repository code (ensures your changes don't break existing functionality):
 
 ```bash
-# Clean the code with `go`
-go mod tidy
-go fmt ./...
-go vet ./...
+# execute the `test` target with `make`
+make test
+```
+
+* Clean the repository code (ensures your code meets the project standards):
+
+```bash
+# execute the `test` target with `make`
+make clean
 ```
 
 * Push to your fork:
 
 ```bash
-# Push your code up to your fork
+# push your code up to your fork
 git push fork master
 ```
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by
@@ -72,7 +72,7 @@ linters:
   enable:
     - bodyclose
     - deadcode # enabled by default
-    - dupl
+    # - dupl # ignoring for this repo
     - errcheck # enabled by default
     - funlen
     - goconst
@@ -87,7 +87,7 @@ linters:
     - gosimple # enabled by default
     - govet # enabled by default
     - ineffassign # enabled by default
-    - lll
+    # - lll # ignoring for this repo
     - maligned
     - misspell
     - nakedret

--- a/docker/container.go
+++ b/docker/container.go
@@ -62,7 +62,8 @@ func (c *ContainerService) ContainerCreate(ctx context.Context, config *containe
 	if strings.Contains(ctn, "notfound") &&
 		!strings.Contains(ctn, "ignorenotfound") {
 		return container.ContainerCreateCreatedBody{},
-			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	// check if the container is not-found and
@@ -70,7 +71,8 @@ func (c *ContainerService) ContainerCreate(ctx context.Context, config *containe
 	if strings.Contains(ctn, "not-found") &&
 		!strings.Contains(ctn, "ignore-not-found") {
 		return container.ContainerCreateCreatedBody{},
-			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	// check if the image is not found
@@ -78,7 +80,8 @@ func (c *ContainerService) ContainerCreate(ctx context.Context, config *containe
 		strings.Contains(config.Image, "not-found") {
 		return container.ContainerCreateCreatedBody{},
 			errdefs.NotFound(
-				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", config.Image),
+				// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", config.Image),
 			)
 	}
 
@@ -168,7 +171,8 @@ func (c *ContainerService) ContainerInspect(ctx context.Context, ctn string) (ty
 	if strings.Contains(ctn, "notfound") &&
 		!strings.Contains(ctn, "ignorenotfound") {
 		return types.ContainerJSON{},
-			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	// check if the container is not-found and
@@ -176,7 +180,8 @@ func (c *ContainerService) ContainerInspect(ctx context.Context, ctn string) (ty
 	if strings.Contains(ctn, "not-found") &&
 		!strings.Contains(ctn, "ignore-not-found") {
 		return types.ContainerJSON{},
-			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	// create response object to return
@@ -211,7 +216,8 @@ func (c *ContainerService) ContainerInspectWithRaw(ctx context.Context, ctn stri
 		strings.Contains(ctn, "not-found") {
 		return types.ContainerJSON{},
 			nil,
-			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	// create response object to return
@@ -249,7 +255,8 @@ func (c *ContainerService) ContainerKill(ctx context.Context, ctn, signal string
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") ||
 		strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+		// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -277,7 +284,8 @@ func (c *ContainerService) ContainerLogs(ctx context.Context, ctn string, option
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") ||
 		strings.Contains(ctn, "not-found") {
-		return nil, errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+		// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+		return nil, errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	// create response object to return
@@ -322,7 +330,8 @@ func (c *ContainerService) ContainerRemove(ctx context.Context, ctn string, opti
 
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") || strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+		// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -365,7 +374,8 @@ func (c *ContainerService) ContainerStart(ctx context.Context, ctn string, optio
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") ||
 		strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+		// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -401,7 +411,8 @@ func (c *ContainerService) ContainerStop(ctx context.Context, ctn string, timeou
 
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") || strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+		// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -452,7 +463,8 @@ func (c *ContainerService) ContainerWait(ctx context.Context, ctn string, condit
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") || strings.Contains(ctn, "not-found") {
 		// propagate the error to the error channel
-		errCh <- errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
+		// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+		errCh <- errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
 
 		return ctnCh, errCh
 	}

--- a/docker/container.go
+++ b/docker/container.go
@@ -62,7 +62,7 @@ func (c *ContainerService) ContainerCreate(ctx context.Context, config *containe
 	if strings.Contains(ctn, "notfound") &&
 		!strings.Contains(ctn, "ignorenotfound") {
 		return container.ContainerCreateCreatedBody{},
-			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	// check if the container is not-found and
@@ -70,7 +70,7 @@ func (c *ContainerService) ContainerCreate(ctx context.Context, config *containe
 	if strings.Contains(ctn, "not-found") &&
 		!strings.Contains(ctn, "ignore-not-found") {
 		return container.ContainerCreateCreatedBody{},
-			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	// check if the image is not found
@@ -78,7 +78,7 @@ func (c *ContainerService) ContainerCreate(ctx context.Context, config *containe
 		strings.Contains(config.Image, "not-found") {
 		return container.ContainerCreateCreatedBody{},
 			errdefs.NotFound(
-				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", config.Image),
+				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", config.Image),
 			)
 	}
 
@@ -168,7 +168,7 @@ func (c *ContainerService) ContainerInspect(ctx context.Context, ctn string) (ty
 	if strings.Contains(ctn, "notfound") &&
 		!strings.Contains(ctn, "ignorenotfound") {
 		return types.ContainerJSON{},
-			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	// check if the container is not-found and
@@ -176,7 +176,7 @@ func (c *ContainerService) ContainerInspect(ctx context.Context, ctn string) (ty
 	if strings.Contains(ctn, "not-found") &&
 		!strings.Contains(ctn, "ignore-not-found") {
 		return types.ContainerJSON{},
-			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	// create response object to return
@@ -211,7 +211,7 @@ func (c *ContainerService) ContainerInspectWithRaw(ctx context.Context, ctn stri
 		strings.Contains(ctn, "not-found") {
 		return types.ContainerJSON{},
 			nil,
-			errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+			errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	// create response object to return
@@ -249,7 +249,7 @@ func (c *ContainerService) ContainerKill(ctx context.Context, ctn, signal string
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") ||
 		strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -277,7 +277,7 @@ func (c *ContainerService) ContainerLogs(ctx context.Context, ctn string, option
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") ||
 		strings.Contains(ctn, "not-found") {
-		return nil, errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+		return nil, errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	// create response object to return
@@ -322,7 +322,7 @@ func (c *ContainerService) ContainerRemove(ctx context.Context, ctn string, opti
 
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") || strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -365,7 +365,7 @@ func (c *ContainerService) ContainerStart(ctx context.Context, ctn string, optio
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") ||
 		strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -401,7 +401,7 @@ func (c *ContainerService) ContainerStop(ctx context.Context, ctn string, timeou
 
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") || strings.Contains(ctn, "not-found") {
-		return errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+		return errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 	}
 
 	return nil
@@ -452,7 +452,7 @@ func (c *ContainerService) ContainerWait(ctx context.Context, ctn string, condit
 	// check if the container is not found
 	if strings.Contains(ctn, "notfound") || strings.Contains(ctn, "not-found") {
 		// propagate the error to the error channel
-		errCh <- errdefs.NotFound(fmt.Errorf("Error: No such container: %s", ctn))
+		errCh <- errdefs.NotFound(fmt.Errorf("error: No such container: %s", ctn))
 
 		return ctnCh, errCh
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -10,6 +10,7 @@ const Version = "v1.40"
 
 // New returns a client that is capable of handling
 // Docker client calls and returning stub responses.
+// nolint:golint // returning unexported type intentionally
 func New() (*mock, error) {
 	return &mock{
 		ConfigService:       ConfigService{},

--- a/docker/image.go
+++ b/docker/image.go
@@ -90,7 +90,8 @@ func (i *ImageService) ImageInspectWithRaw(ctx context.Context, image string) (t
 		return types.ImageInspect{},
 			nil,
 			errdefs.NotFound(
-				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", image),
+				// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),
 			)
 	}
 
@@ -164,7 +165,8 @@ func (i *ImageService) ImagePull(ctx context.Context, image string, options type
 		!strings.Contains(image, "ignorenotfound") {
 		return nil,
 			errdefs.NotFound(
-				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", image),
+				// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),
 			)
 	}
 
@@ -174,7 +176,8 @@ func (i *ImageService) ImagePull(ctx context.Context, image string, options type
 		!strings.Contains(image, "ignore-not-found") {
 		return nil,
 			errdefs.NotFound(
-				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", image),
+				// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),
 			)
 	}
 

--- a/docker/image.go
+++ b/docker/image.go
@@ -90,7 +90,7 @@ func (i *ImageService) ImageInspectWithRaw(ctx context.Context, image string) (t
 		return types.ImageInspect{},
 			nil,
 			errdefs.NotFound(
-				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),
+				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", image),
 			)
 	}
 
@@ -164,7 +164,7 @@ func (i *ImageService) ImagePull(ctx context.Context, image string, options type
 		!strings.Contains(image, "ignorenotfound") {
 		return nil,
 			errdefs.NotFound(
-				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),
+				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", image),
 			)
 	}
 
@@ -174,7 +174,7 @@ func (i *ImageService) ImagePull(ctx context.Context, image string, options type
 		!strings.Contains(image, "ignore-not-found") {
 		return nil,
 			errdefs.NotFound(
-				fmt.Errorf("Error response from daemon: manifest for %s not found: manifest unknown", image),
+				fmt.Errorf("error response from daemon: manifest for %s not found: manifest unknown", image),
 			)
 	}
 

--- a/docker/network.go
+++ b/docker/network.go
@@ -47,7 +47,7 @@ func (n *NetworkService) NetworkCreate(ctx context.Context, name string, options
 	if strings.Contains(name, "notfound") &&
 		!strings.Contains(name, "ignorenotfound") {
 		return types.NetworkCreateResponse{},
-			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", name))
+			errdefs.NotFound(fmt.Errorf("error: No such network: %s", name))
 	}
 
 	// check if the network is not-found and
@@ -55,7 +55,7 @@ func (n *NetworkService) NetworkCreate(ctx context.Context, name string, options
 	if strings.Contains(name, "not-found") &&
 		!strings.Contains(name, "ignore-not-found") {
 		return types.NetworkCreateResponse{},
-			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", name))
+			errdefs.NotFound(fmt.Errorf("error: No such network: %s", name))
 	}
 
 	// create response object to return
@@ -87,13 +87,13 @@ func (n *NetworkService) NetworkInspect(ctx context.Context, network string, opt
 	// check if the network is notfound
 	if strings.Contains(network, "notfound") {
 		return types.NetworkResource{},
-			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", network))
+			errdefs.NotFound(fmt.Errorf("error: No such network: %s", network))
 	}
 
 	// check if the network is not-found
 	if strings.Contains(network, "not-found") {
 		return types.NetworkResource{},
-			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", network))
+			errdefs.NotFound(fmt.Errorf("error: No such network: %s", network))
 	}
 
 	// create response object to return

--- a/docker/network.go
+++ b/docker/network.go
@@ -47,7 +47,8 @@ func (n *NetworkService) NetworkCreate(ctx context.Context, name string, options
 	if strings.Contains(name, "notfound") &&
 		!strings.Contains(name, "ignorenotfound") {
 		return types.NetworkCreateResponse{},
-			errdefs.NotFound(fmt.Errorf("error: No such network: %s", name))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", name))
 	}
 
 	// check if the network is not-found and
@@ -55,7 +56,8 @@ func (n *NetworkService) NetworkCreate(ctx context.Context, name string, options
 	if strings.Contains(name, "not-found") &&
 		!strings.Contains(name, "ignore-not-found") {
 		return types.NetworkCreateResponse{},
-			errdefs.NotFound(fmt.Errorf("error: No such network: %s", name))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", name))
 	}
 
 	// create response object to return
@@ -87,13 +89,15 @@ func (n *NetworkService) NetworkInspect(ctx context.Context, network string, opt
 	// check if the network is notfound
 	if strings.Contains(network, "notfound") {
 		return types.NetworkResource{},
-			errdefs.NotFound(fmt.Errorf("error: No such network: %s", network))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", network))
 	}
 
 	// check if the network is not-found
 	if strings.Contains(network, "not-found") {
 		return types.NetworkResource{},
-			errdefs.NotFound(fmt.Errorf("error: No such network: %s", network))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such network: %s", network))
 	}
 
 	// create response object to return

--- a/docker/volume.go
+++ b/docker/volume.go
@@ -39,7 +39,8 @@ func (v *VolumeService) VolumeCreate(ctx context.Context, options volume.VolumeC
 	if strings.Contains(options.Name, "notfound") &&
 		!strings.Contains(options.Name, "ignorenotfound") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", options.Name))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", options.Name))
 	}
 
 	// check if the volume is not-found and
@@ -47,7 +48,8 @@ func (v *VolumeService) VolumeCreate(ctx context.Context, options volume.VolumeC
 	if strings.Contains(options.Name, "not-found") &&
 		!strings.Contains(options.Name, "ignore-not-found") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", options.Name))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", options.Name))
 	}
 
 	// create response object to return
@@ -77,13 +79,15 @@ func (v *VolumeService) VolumeInspect(ctx context.Context, volumeID string) (typ
 	// check if the volume is notfound
 	if strings.Contains(volumeID, "notfound") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
 	}
 
 	// check if the volume is not-found
 	if strings.Contains(volumeID, "not-found") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
 	}
 
 	// create response object to return
@@ -112,13 +116,15 @@ func (v *VolumeService) VolumeInspectWithRaw(ctx context.Context, volumeID strin
 	// check if the volume is notfound
 	if strings.Contains(volumeID, "notfound") {
 		return types.Volume{}, nil,
-			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
 	}
 
 	// check if the volume is not-found
 	if strings.Contains(volumeID, "not-found") {
 		return types.Volume{}, nil,
-			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
+			// nolint:golint,stylecheck // messsage is capitalized to match Docker messages
+			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
 	}
 
 	// create response object to return

--- a/docker/volume.go
+++ b/docker/volume.go
@@ -39,7 +39,7 @@ func (v *VolumeService) VolumeCreate(ctx context.Context, options volume.VolumeC
 	if strings.Contains(options.Name, "notfound") &&
 		!strings.Contains(options.Name, "ignorenotfound") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", options.Name))
+			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", options.Name))
 	}
 
 	// check if the volume is not-found and
@@ -47,7 +47,7 @@ func (v *VolumeService) VolumeCreate(ctx context.Context, options volume.VolumeC
 	if strings.Contains(options.Name, "not-found") &&
 		!strings.Contains(options.Name, "ignore-not-found") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", options.Name))
+			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", options.Name))
 	}
 
 	// create response object to return
@@ -77,13 +77,13 @@ func (v *VolumeService) VolumeInspect(ctx context.Context, volumeID string) (typ
 	// check if the volume is notfound
 	if strings.Contains(volumeID, "notfound") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
+			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
 	}
 
 	// check if the volume is not-found
 	if strings.Contains(volumeID, "not-found") {
 		return types.Volume{},
-			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
+			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
 	}
 
 	// create response object to return
@@ -112,13 +112,13 @@ func (v *VolumeService) VolumeInspectWithRaw(ctx context.Context, volumeID strin
 	// check if the volume is notfound
 	if strings.Contains(volumeID, "notfound") {
 		return types.Volume{}, nil,
-			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
+			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
 	}
 
 	// check if the volume is not-found
 	if strings.Contains(volumeID, "not-found") {
 		return types.Volume{}, nil,
-			errdefs.NotFound(fmt.Errorf("Error: No such volume: %s", volumeID))
+			errdefs.NotFound(fmt.Errorf("error: No such volume: %s", volumeID))
 	}
 
 	// create response object to return

--- a/server/build.go
+++ b/server/build.go
@@ -160,14 +160,14 @@ func getBuild(c *gin.Context) {
 
 // getLogs has a param :build returns mock JSON for a http GET.
 //
-// Pass "0" to :build to test receiving a http 404 response
+// Pass "0" to :build to test receiving a http 404 response.
 func getLogs(c *gin.Context) {
 	b := c.Param("build")
 
 	if strings.EqualFold(b, "0") {
 		msg := fmt.Sprintf("Build %s does not exist", b)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}
@@ -216,7 +216,7 @@ func updateBuild(c *gin.Context) {
 
 // removeBuild has a param :build returns mock JSON for a http DELETE.
 //
-// Pass "0" to :build to test receiving a http 404 response
+// Pass "0" to :build to test receiving a http 404 response.
 func removeBuild(c *gin.Context) {
 	b := c.Param("build")
 
@@ -233,7 +233,7 @@ func removeBuild(c *gin.Context) {
 
 // restartBuild has a param :build returns mock JSON for a http POST.
 //
-// Pass "0" to :build to test receiving a http 404 response
+// Pass "0" to :build to test receiving a http 404 response.
 func restartBuild(c *gin.Context) {
 	b := c.Param("build")
 

--- a/server/hook.go
+++ b/server/hook.go
@@ -77,7 +77,7 @@ func getHooks(c *gin.Context) {
 
 // getHook has a param :hook returns mock JSON for a http GET.
 //
-// Pass "0" to :hook to test receiving a http 404 response
+// Pass "0" to :hook to test receiving a http 404 response.
 func getHook(c *gin.Context) {
 	s := c.Param("hook")
 
@@ -109,7 +109,7 @@ func addHook(c *gin.Context) {
 
 // updateHook has a param :hook returns mock JSON for a http PUT.
 //
-// Pass "0" to :hook to test receiving a http 404 response
+// Pass "0" to :hook to test receiving a http 404 response.
 func updateHook(c *gin.Context) {
 	if !strings.Contains(c.FullPath(), "admin") {
 		s := c.Param("hook")
@@ -133,7 +133,7 @@ func updateHook(c *gin.Context) {
 
 // removeHook has a param :hook returns mock JSON for a http DELETE.
 //
-// Pass "0" to :hook to test receiving a http 404 response
+// Pass "0" to :hook to test receiving a http 404 response.
 func removeHook(c *gin.Context) {
 	s := c.Param("hook")
 

--- a/server/log.go
+++ b/server/log.go
@@ -29,7 +29,7 @@ const (
 
 // getServiceLog has a param :service returns mock JSON for a http GET.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func getServiceLog(c *gin.Context) {
 	s := c.Param("service")
 
@@ -61,7 +61,7 @@ func addServiceLog(c *gin.Context) {
 
 // updateServiceLog has a param :service returns mock JSON for a http PUT.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func updateServiceLog(c *gin.Context) {
 	s := c.Param("service")
 
@@ -83,7 +83,7 @@ func updateServiceLog(c *gin.Context) {
 
 // removeServiceLog has a param :service returns mock JSON for a http DELETE.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func removeServiceLog(c *gin.Context) {
 	s := c.Param("service")
 
@@ -100,7 +100,7 @@ func removeServiceLog(c *gin.Context) {
 
 // getStepLog has a param :step returns mock JSON for a http GET.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func getStepLog(c *gin.Context) {
 	s := c.Param("step")
 
@@ -132,7 +132,7 @@ func addStepLog(c *gin.Context) {
 
 // updateStepLog has a param :step returns mock JSON for a http PUT.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func updateStepLog(c *gin.Context) {
 	s := c.Param("step")
 
@@ -154,7 +154,7 @@ func updateStepLog(c *gin.Context) {
 
 // removeStepLog has a param :step returns mock JSON for a http DELETE.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func removeStepLog(c *gin.Context) {
 	s := c.Param("step")
 

--- a/server/pipeline.go
+++ b/server/pipeline.go
@@ -145,14 +145,14 @@ sample:
 
 // getPipeline has a param :repo returns mock YAML for a http GET.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func getPipeline(c *gin.Context) {
 	r := c.Param("repo")
 
 	if strings.Contains(r, "not-found") {
 		msg := fmt.Sprintf("Repo %s does not exist", r)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}
@@ -167,14 +167,14 @@ func getPipeline(c *gin.Context) {
 
 // compilePipeline has a param :repo returns mock YAML for a http GET.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func compilePipeline(c *gin.Context) {
 	r := c.Param("repo")
 
 	if strings.Contains(r, "not-found") {
 		msg := fmt.Sprintf("Repo %s does not exist", r)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}
@@ -189,14 +189,14 @@ func compilePipeline(c *gin.Context) {
 
 // expandPipeline has a param :repo returns mock YAML for a http GET.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func expandPipeline(c *gin.Context) {
 	r := c.Param("repo")
 
 	if strings.Contains(r, "not-found") {
 		msg := fmt.Sprintf("Repo %s does not exist", r)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}
@@ -211,14 +211,14 @@ func expandPipeline(c *gin.Context) {
 
 // getTemplates has a param :repo returns mock YAML for a http GET.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func getTemplates(c *gin.Context) {
 	r := c.Param("repo")
 
 	if strings.Contains(r, "not-found") {
 		msg := fmt.Sprintf("Repo %s does not exist", r)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}
@@ -233,14 +233,14 @@ func getTemplates(c *gin.Context) {
 
 // validatePipeline has a param :repo returns mock YAML for a http GET.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func validatePipeline(c *gin.Context) {
 	r := c.Param("repo")
 
 	if strings.Contains(r, "not-found") {
 		msg := fmt.Sprintf("Repo %s does not exist", r)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}

--- a/server/repo.go
+++ b/server/repo.go
@@ -92,14 +92,14 @@ func getRepos(c *gin.Context) {
 
 // getRepo has a param :repo returns mock JSON for a http GET.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func getRepo(c *gin.Context) {
 	r := c.Param("repo")
 
 	if strings.Contains(r, "not-found") {
 		msg := fmt.Sprintf("Repo %s does not exist", r)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}
@@ -124,7 +124,7 @@ func addRepo(c *gin.Context) {
 
 // updateRepo has a param :repo returns mock JSON for a http PUT.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func updateRepo(c *gin.Context) {
 	if !strings.Contains(c.FullPath(), "admin") {
 		r := c.Param("repo")
@@ -148,7 +148,7 @@ func updateRepo(c *gin.Context) {
 
 // removeRepo has a param :repo returns mock JSON for a http DELETE.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func removeRepo(c *gin.Context) {
 	r := c.Param("repo")
 
@@ -165,7 +165,7 @@ func removeRepo(c *gin.Context) {
 
 // repairRepo has a param :repo returns mock JSON for a http PATCH.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func repairRepo(c *gin.Context) {
 	r := c.Param("repo")
 
@@ -182,7 +182,7 @@ func repairRepo(c *gin.Context) {
 
 // chownRepo has a param :repo returns mock JSON for a http PATCH.
 //
-// Pass "not-found" to :repo to test receiving a http 404 response
+// Pass "not-found" to :repo to test receiving a http 404 response.
 func chownRepo(c *gin.Context) {
 	r := c.Param("repo")
 

--- a/server/secret.go
+++ b/server/secret.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-vela/types/library"
 )
 
+// nolint:gosec // these are mock responses
 const (
 	// SecretResp represents a JSON return for a single secret.
 	SecretResp = `{
@@ -95,14 +96,14 @@ func getSecrets(c *gin.Context) {
 
 // getSecret has a param :name returns mock JSON for a http GET.
 //
-// Pass "not-found" to :name to test receiving a http 404 response
+// Pass "not-found" to :name to test receiving a http 404 response.
 func getSecret(c *gin.Context) {
 	n := c.Param("name")
 
 	if strings.Contains(n, "not-found") {
 		msg := fmt.Sprintf("Secret %s does not exist", n)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}
@@ -127,7 +128,7 @@ func addSecret(c *gin.Context) {
 
 // updateSecret has a param :name returns mock JSON for a http PUT.
 //
-// Pass "not-found" to :name to test receiving a http 404 response
+// Pass "not-found" to :name to test receiving a http 404 response.
 func updateSecret(c *gin.Context) {
 	if !strings.Contains(c.FullPath(), "admin") {
 		n := c.Param("name")
@@ -151,7 +152,7 @@ func updateSecret(c *gin.Context) {
 
 // removeSecret has a param :name returns mock JSON for a http DELETE.
 //
-// Pass "not-found" to :name to test receiving a http 404 response
+// Pass "not-found" to :name to test receiving a http 404 response.
 func removeSecret(c *gin.Context) {
 	n := c.Param("name")
 

--- a/server/server.go
+++ b/server/server.go
@@ -12,6 +12,7 @@ import (
 
 // FakeHandler returns an http.Handler that is capable of handling
 // Vela API requests and returning mock responses.
+// nolint:funlen // number of endpoints is causing linter warning
 func FakeHandler() http.Handler {
 	gin.SetMode(gin.TestMode)
 

--- a/server/service.go
+++ b/server/service.go
@@ -74,7 +74,7 @@ func getServices(c *gin.Context) {
 
 // getService has a param :service returns mock JSON for a http GET.
 //
-// Pass "0" to :service to test receiving a http 404 response
+// Pass "0" to :service to test receiving a http 404 response.
 func getService(c *gin.Context) {
 	s := c.Param("service")
 
@@ -106,7 +106,7 @@ func addService(c *gin.Context) {
 
 // updateService has a param :service returns mock JSON for a http PUT.
 //
-// Pass "0" to :service to test receiving a http 404 response
+// Pass "0" to :service to test receiving a http 404 response.
 func updateService(c *gin.Context) {
 	if !strings.Contains(c.FullPath(), "admin") {
 		s := c.Param("service")
@@ -130,7 +130,7 @@ func updateService(c *gin.Context) {
 
 // removeService has a param :service returns mock JSON for a http DELETE.
 //
-// Pass "0" to :service to test receiving a http 404 response
+// Pass "0" to :service to test receiving a http 404 response.
 func removeService(c *gin.Context) {
 	s := c.Param("service")
 
@@ -142,5 +142,5 @@ func removeService(c *gin.Context) {
 		return
 	}
 
-	c.JSON(200, fmt.Sprintf("Service %s removed", s))
+	c.JSON(http.StatusOK, fmt.Sprintf("Service %s removed", s))
 }

--- a/server/step.go
+++ b/server/step.go
@@ -83,7 +83,7 @@ func getSteps(c *gin.Context) {
 
 // getStep has a param :step returns mock JSON for a http GET.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func getStep(c *gin.Context) {
 	s := c.Param("step")
 
@@ -115,7 +115,7 @@ func addStep(c *gin.Context) {
 
 // updateStep has a param :step returns mock JSON for a http PUT.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func updateStep(c *gin.Context) {
 	if !strings.Contains(c.FullPath(), "admin") {
 		s := c.Param("step")
@@ -139,7 +139,7 @@ func updateStep(c *gin.Context) {
 
 // removeStep has a param :step returns mock JSON for a http DELETE.
 //
-// Pass "0" to :step to test receiving a http 404 response
+// Pass "0" to :step to test receiving a http 404 response.
 func removeStep(c *gin.Context) {
 	s := c.Param("step")
 
@@ -151,5 +151,5 @@ func removeStep(c *gin.Context) {
 		return
 	}
 
-	c.JSON(200, fmt.Sprintf("Step %s removed", s))
+	c.JSON(http.StatusOK, fmt.Sprintf("Step %s removed", s))
 }

--- a/server/user.go
+++ b/server/user.go
@@ -59,7 +59,7 @@ func getUsers(c *gin.Context) {
 
 // getUser has a param :user returns mock JSON for a http GET.
 //
-// Pass "not-found" to :user to test receiving a http 404 response
+// Pass "not-found" to :user to test receiving a http 404 response.
 func getUser(c *gin.Context) {
 	u := c.Param("user")
 
@@ -91,7 +91,7 @@ func addUser(c *gin.Context) {
 
 // updateUser has a param :user returns mock JSON for a http PUT.
 //
-// Pass "not-found" to :user to test receiving a http 404 response
+// Pass "not-found" to :user to test receiving a http 404 response.
 func updateUser(c *gin.Context) {
 	if !strings.Contains(c.FullPath(), "admin") {
 		u := c.Param("user")
@@ -115,7 +115,7 @@ func updateUser(c *gin.Context) {
 
 // removeUser has a param :user returns mock JSON for a http DELETE.
 //
-// Pass "not-found" to :user to test receiving a http 404 response
+// Pass "not-found" to :user to test receiving a http 404 response.
 func removeUser(c *gin.Context) {
 	u := c.Param("user")
 

--- a/server/worker.go
+++ b/server/worker.go
@@ -102,7 +102,7 @@ func addWorker(c *gin.Context) {
 
 // updateWorker has a param :worker returns mock JSON for a http PUT.
 //
-// Pass "0" to :worker to test receiving a http 404 response
+// Pass "0" to :worker to test receiving a http 404 response.
 func updateWorker(c *gin.Context) {
 	w := c.Param("worker")
 
@@ -124,14 +124,14 @@ func updateWorker(c *gin.Context) {
 
 // removeWorker has a param :worker returns mock JSON for a http DELETE.
 //
-// Pass "0" to :worker to test receiving a http 404 response
+// Pass "0" to :worker to test receiving a http 404 response.
 func removeWorker(c *gin.Context) {
 	w := c.Param("worker")
 
 	if strings.EqualFold(w, "0") {
 		msg := fmt.Sprintf("Worker %s does not exist", w)
 
-		c.AbortWithStatusJSON(404, types.Error{Message: &msg})
+		c.AbortWithStatusJSON(http.StatusNotFound, types.Error{Message: &msg})
 
 		return
 	}


### PR DESCRIPTION
similar change to https://github.com/go-vela/types/pull/122

for this repo, i decided to disable `lll` and `dupl` linter because I felt like this repo in particular will be prone to trigger these, some of which will be false positives. let me know if you think otherwise :bow: 